### PR TITLE
Add hybrid mode scripts to CLI data

### DIFF
--- a/cli-data/build-scripts/899c20f5-63d6-47fc-9250-32b5cd2c3aef
+++ b/cli-data/build-scripts/899c20f5-63d6-47fc-9250-32b5cd2c3aef
@@ -1,0 +1,18 @@
+cd $SPREE_CLI_PROJECT_NAME
+cd $SPREE_CLI_PATH_BACKEND
+rm -rf .env && cp -f .env.sample .env &&
+docker-compose pull | awk -v prefix="[backend]" '{ print prefix, $0 }' &&
+docker-compose build web | awk -v prefix="[backend]" '{ print prefix, $0 }' &&
+docker-compose run --rm web bash -c '
+  bin/wait-for-services &&
+  (bundle check || bundle install) &&
+  bundle exec rails db:drop &&
+  bundle exec rails db:create &&
+  bundle exec rails db:migrate &&
+  echo -en "spree@example.com" | bundle exec rails db:seed &&
+  rm -rf tmp/latest.dump
+' | awk -v prefix="[backend]" '{ print prefix, $0 }' &&
+docker-compose run web rake spree_sample:load | awk -v prefix="[backend]" '{ print prefix, $0 }'
+docker-compose up redis postgres | awk -v prefix="[backend]" '{ print prefix, $0 }' &
+(while [ "`docker inspect -f {{.State.Running}} spree_starter-main_postgres_1`" != "true" ]; do     sleep 2; done &&
+bin/rails s)

--- a/cli-data/build-scripts/da7cfc54-c270-46c8-96c5-c54181e0424c
+++ b/cli-data/build-scripts/da7cfc54-c270-46c8-96c5-c54181e0424c
@@ -1,0 +1,18 @@
+cd $SPREE_CLI_PROJECT_NAME
+cd $SPREE_CLI_PATH_BACKEND
+rm -rf .env && cp -f .env.sample .env &&
+docker-compose pull | awk -v prefix="[backend]" '{ print prefix, $0 }' &&
+docker-compose build web | awk -v prefix="[backend]" '{ print prefix, $0 }' &&
+docker-compose run --rm web bash -c '
+  bin/wait-for-services &&
+  (bundle check || bundle install) &&
+  bundle exec rails db:drop &&
+  bundle exec rails db:create &&
+  bundle exec rails db:migrate &&
+  echo -en "spree@example.com" | bundle exec rails db:seed &&
+  rm -rf tmp/latest.dump
+' | awk -v prefix="[backend]" '{ print prefix, $0 }'
+docker-compose up redis postgres | awk -v prefix="[backend]" '{ print prefix, $0 }' &
+(while [ "`docker inspect -f {{.State.Running}} spree_starter-main_postgres_1`" != "true" ]; do     sleep 2; done &&
+bin/rails s)
+

--- a/cli-data/run-scripts/da7cfc54-c270-46c8-96c5-c54181e0424c
+++ b/cli-data/run-scripts/da7cfc54-c270-46c8-96c5-c54181e0424c
@@ -1,0 +1,5 @@
+cd $SPREE_CLI_PROJECT_NAME
+cd $SPREE_CLI_PATH_BACKEND
+docker-compose up redis postgres | awk -v prefix="[backend]" '{ print prefix, $0 }' &
+(while [ "`docker inspect -f {{.State.Running}} spree_starter-main_postgres_1`" != "true" ]; do     sleep 2; done &&
+bin/rails s)

--- a/cli-data/spree/data.json
+++ b/cli-data/spree/data.json
@@ -54,6 +54,7 @@
     "gitRepositoryURL": "https://github.com/spree/spree_starter",
     "documentationURL": "https://dev-docs.spreecommerce.org/",
     "buildScriptPath": "/build-scripts/da7cfc54-c270-46c8-96c5-c54181e0424c",
+    "runScriptPath": "/run-scripts/da7cfc54-c270-46c8-96c5-c54181e0424c",
     "dependencies": {
       "docker": ">= 20.0",
       "ruby": "= 3.0.3"
@@ -66,6 +67,7 @@
     "gitRepositoryURL": "https://github.com/spree/spree_starter",
     "documentationURL": "https://dev-docs.spreecommerce.org/",
     "buildScriptPath": "/build-scripts/899c20f5-63d6-47fc-9250-32b5cd2c3aef",
+    "runScriptPath": "/run-scripts/da7cfc54-c270-46c8-96c5-c54181e0424c",
     "dependencies": {
       "docker": ">= 20.0",
       "ruby": "= 3.0.3"

--- a/cli-data/spree/data.json
+++ b/cli-data/spree/data.json
@@ -46,5 +46,29 @@
     "dependencies": {
       "ruby": "= 3.0.3"
     }
+  },
+  {
+    "id": "da7cfc54-c270-46c8-96c5-c54181e0424c",
+    "name": "Spree (hybrid)",
+    "version": "no-docker",
+    "gitRepositoryURL": "https://github.com/spree/spree_starter",
+    "documentationURL": "https://dev-docs.spreecommerce.org/",
+    "buildScriptPath": "/build-scripts/da7cfc54-c270-46c8-96c5-c54181e0424c",
+    "dependencies": {
+      "docker": ">= 20.0",
+      "ruby": "= 3.0.3"
+    }
+  },
+  {
+    "id": "899c20f5-63d6-47fc-9250-32b5cd2c3aef",
+    "name": "Spree (hybrid with samples)",
+    "version": "no-docker",
+    "gitRepositoryURL": "https://github.com/spree/spree_starter",
+    "documentationURL": "https://dev-docs.spreecommerce.org/",
+    "buildScriptPath": "/build-scripts/899c20f5-63d6-47fc-9250-32b5cd2c3aef",
+    "dependencies": {
+      "docker": ">= 20.0",
+      "ruby": "= 3.0.3"
+    }
   }
 ]

--- a/cli-data/spree/data.json
+++ b/cli-data/spree/data.json
@@ -50,7 +50,7 @@
   {
     "id": "da7cfc54-c270-46c8-96c5-c54181e0424c",
     "name": "Spree (hybrid)",
-    "version": "no-docker",
+    "version": "hybrid",
     "gitRepositoryURL": "https://github.com/spree/spree_starter",
     "documentationURL": "https://dev-docs.spreecommerce.org/",
     "buildScriptPath": "/build-scripts/da7cfc54-c270-46c8-96c5-c54181e0424c",
@@ -62,7 +62,7 @@
   {
     "id": "899c20f5-63d6-47fc-9250-32b5cd2c3aef",
     "name": "Spree (hybrid with samples)",
-    "version": "no-docker",
+    "version": "hybrid",
     "gitRepositoryURL": "https://github.com/spree/spree_starter",
     "documentationURL": "https://dev-docs.spreecommerce.org/",
     "buildScriptPath": "/build-scripts/899c20f5-63d6-47fc-9250-32b5cd2c3aef",


### PR DESCRIPTION
Added scripts that are responsible of launching spree backend in hybrid mode 

Merge it only after [hybrid-mode](https://github.com/spree/spree_starter/pull/1014) is merged to spree starter otherwise  those will not work properly and rails server will not start